### PR TITLE
Add force loaded chunks tab to tracking tab

### DIFF
--- a/src/main/java/mcp/mobius/opis/data/holders/DataType.java
+++ b/src/main/java/mcp/mobius/opis/data/holders/DataType.java
@@ -29,6 +29,7 @@ import mcp.mobius.opis.data.holders.newtypes.DataDimension;
 import mcp.mobius.opis.data.holders.newtypes.DataEntity;
 import mcp.mobius.opis.data.holders.newtypes.DataEntityPerClass;
 import mcp.mobius.opis.data.holders.newtypes.DataEvent;
+import mcp.mobius.opis.data.holders.newtypes.DataForcedChunks;
 import mcp.mobius.opis.data.holders.newtypes.DataNetworkTick;
 import mcp.mobius.opis.data.holders.newtypes.DataPacket;
 import mcp.mobius.opis.data.holders.newtypes.DataPacket250;
@@ -69,6 +70,7 @@ public enum DataType {
     DATACHUNK(DataChunk.class),
     DATACHUNKENTITIES(DataChunkEntities.class),
     DATADIMENSION(DataDimension.class),
+    DATAFORCEDCHUNKS(DataForcedChunks.class),
     DATAENTITY(DataEntity.class),
     DATAENTITYPERCLASS(DataEntityPerClass.class),
     DATAENTITYRENDER(DataEntityRender.class),

--- a/src/main/java/mcp/mobius/opis/data/holders/newtypes/DataForcedChunks.java
+++ b/src/main/java/mcp/mobius/opis/data/holders/newtypes/DataForcedChunks.java
@@ -150,6 +150,8 @@ public class DataForcedChunks implements ISerializable {
             type = raw.getString("id");
         } else if (raw.hasKey("townName", Constants.NBT.TAG_STRING)) { // MyTown2
             type = "Town: " + raw.getString("townName");
+        } else if (raw.hasKey("poppetX", Constants.NBT.TAG_INT)) { // Witchery
+            type = "Poppet";
         }
 
         if (type != null) {

--- a/src/main/java/mcp/mobius/opis/data/holders/newtypes/DataForcedChunks.java
+++ b/src/main/java/mcp/mobius/opis/data/holders/newtypes/DataForcedChunks.java
@@ -99,7 +99,7 @@ public class DataForcedChunks implements ISerializable {
             xCoord = raw.getInteger("xCoord");
         } else if (raw.hasKey("OwnerX", Constants.NBT.TAG_INT)) { // GregTech
             xCoord = raw.getInteger("OwnerX");
-        } else if (raw.hasKey("x", Constants.NBT.TAG_INT)) { // Extra Utilities
+        } else if (raw.hasKey("x", Constants.NBT.TAG_INT)) { // Extra Utilities, OpenComputers
             xCoord = raw.getInteger("x");
         } else if (raw.hasKey("poppetX", Constants.NBT.TAG_INT)) { // Witchery
             xCoord = raw.getInteger("poppetX");
@@ -123,7 +123,7 @@ public class DataForcedChunks implements ISerializable {
             zCoord = raw.getInteger("zCoord");
         } else if (raw.hasKey("OwnerZ", Constants.NBT.TAG_INT)) { // GregTech
             zCoord = raw.getInteger("OwnerZ");
-        } else if (raw.hasKey("z", Constants.NBT.TAG_INT)) { // Extra Utilities
+        } else if (raw.hasKey("z", Constants.NBT.TAG_INT)) { // Extra Utilities, OpenComputers
             zCoord = raw.getInteger("z");
         } else if (raw.hasKey("poppetZ", Constants.NBT.TAG_INT)) { // Witchery
             zCoord = raw.getInteger("poppetZ");

--- a/src/main/java/mcp/mobius/opis/data/holders/newtypes/DataForcedChunks.java
+++ b/src/main/java/mcp/mobius/opis/data/holders/newtypes/DataForcedChunks.java
@@ -1,0 +1,161 @@
+package mcp.mobius.opis.data.holders.newtypes;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.world.ChunkCoordIntPair;
+import net.minecraft.world.WorldServer;
+import net.minecraftforge.common.DimensionManager;
+import net.minecraftforge.common.ForgeChunkManager;
+import net.minecraftforge.common.ForgeChunkManager.Ticket;
+import net.minecraftforge.common.util.Constants;
+
+import com.google.common.collect.SetMultimap;
+import com.google.common.io.ByteArrayDataInput;
+import com.google.common.io.ByteArrayDataOutput;
+
+import mcp.mobius.opis.data.holders.ISerializable;
+
+public class DataForcedChunks implements ISerializable {
+
+    private static final CachedString NONE_CACHED = new CachedString("N/A");
+
+    public int dim;
+    public CachedString dimName;
+    public CachedString modId;
+
+    public CachedString playerOrEntityName;
+
+    public CachedString rawData;
+    public CachedString chunks;
+
+    // Optimistic data we may be able to collect
+    public CachedString position;
+    public CachedString type;
+
+    public static List<DataForcedChunks> getAll(int dim) {
+        WorldServer world = DimensionManager.getWorld(dim);
+        List<DataForcedChunks> dataList = new ArrayList<>();
+
+        CachedString dimName = new CachedString(world.provider.getDimensionName());
+
+        SetMultimap<ChunkCoordIntPair, Ticket> ticketMap = world.getPersistentChunks();
+        Set<Ticket> tickets = new HashSet<>(ticketMap.values());
+        for (Ticket ticket : tickets) {
+            DataForcedChunks data = new DataForcedChunks();
+            dataList.add(data);
+
+            // Basic Information
+            data.dim = dim;
+            data.dimName = dimName;
+            data.modId = new CachedString(ticket.getModId());
+
+            // Report the player name, if available. Otherwise, report the associated entity.
+            // If neither are available, show "N/A."
+            if (ticket.isPlayerTicket()) {
+                data.playerOrEntityName = new CachedString(ticket.getPlayerName());
+            } else if (ticket.getType() == ForgeChunkManager.Type.ENTITY && ticket.getEntity() != null) {
+                Entity entity = ticket.getEntity();
+                data.playerOrEntityName = new CachedString(entity.getClass().getSimpleName());
+            } else {
+                data.playerOrEntityName = NONE_CACHED;
+            }
+
+            // Raw ticket NBT data
+            NBTTagCompound rawData = ticket.getModData();
+            data.rawData = new CachedString(rawData.toString());
+            // Try to parse out optimistic information from the NBT data
+            data.tryParseLocation(rawData);
+            data.tryParseType(rawData);
+
+            // Chunk positions
+            StringBuilder sb = new StringBuilder();
+            Iterator<ChunkCoordIntPair> itr = ticket.getChunkList().iterator();
+            while (itr.hasNext()) {
+                ChunkCoordIntPair coord = itr.next();
+                sb.append("(");
+                sb.append(coord.chunkXPos);
+                sb.append(",");
+                sb.append(coord.chunkZPos);
+                sb.append(")");
+                if (itr.hasNext()) {
+                    sb.append(", ");
+                }
+            }
+            data.chunks = new CachedString(sb.toString());
+        }
+        return dataList;
+    }
+
+    private void tryParseLocation(NBTTagCompound raw) {
+        int xCoord = 0, yCoord = 0, zCoord = 0;
+
+        if (raw.hasKey("xCoord", Constants.NBT.TAG_INT)) { // Railcraft
+            xCoord = raw.getInteger("xCoord");
+        } else if (raw.hasKey("OwnerX", Constants.NBT.TAG_INT)) { // GregTech
+            xCoord = raw.getInteger("OwnerX");
+        }
+
+        if (raw.hasKey("yCoord", Constants.NBT.TAG_INT)) { // Railcraft
+            yCoord = raw.getInteger("yCoord");
+        } else if (raw.hasKey("OwnerY", Constants.NBT.TAG_INT)) { // GregTech
+            yCoord = raw.getInteger("OwnerY");
+        }
+
+        if (raw.hasKey("zCoord", Constants.NBT.TAG_INT)) { // Railcraft
+            zCoord = raw.getInteger("zCoord");
+        } else if (raw.hasKey("OwnerZ", Constants.NBT.TAG_INT)) { // GregTech
+            zCoord = raw.getInteger("OwnerZ");
+        }
+
+        if (xCoord != 0 && yCoord != 0 && zCoord != 0) {
+            position = new CachedString(String.format("[ %4d %4d %4d ]", xCoord, yCoord, zCoord));
+        } else {
+            position = NONE_CACHED;
+        }
+    }
+
+    private void tryParseType(NBTTagCompound raw) {
+        String type = null;
+        if (raw.hasKey("type", Constants.NBT.TAG_STRING)) { // Railcraft
+            type = raw.getString("type");
+        }
+        if (type != null) {
+            this.type = new CachedString(type);
+        } else {
+            this.type = NONE_CACHED;
+        }
+    }
+
+    @Override
+    public void writeToStream(ByteArrayDataOutput stream) {
+        stream.writeInt(dim);
+        dimName.writeToStream(stream);
+        modId.writeToStream(stream);
+        playerOrEntityName.writeToStream(stream);
+        position.writeToStream(stream);
+        type.writeToStream(stream);
+        rawData.writeToStream(stream);
+        chunks.writeToStream(stream);
+    }
+
+    public static DataForcedChunks readFromStream(ByteArrayDataInput stream) {
+        DataForcedChunks retVal = new DataForcedChunks();
+
+        retVal.dim = stream.readInt();
+        retVal.dimName = CachedString.readFromStream(stream);
+        retVal.modId = CachedString.readFromStream(stream);
+        retVal.playerOrEntityName = CachedString.readFromStream(stream);
+        retVal.position = CachedString.readFromStream(stream);
+        retVal.type = CachedString.readFromStream(stream);
+        retVal.rawData = CachedString.readFromStream(stream);
+        retVal.chunks = CachedString.readFromStream(stream);
+
+        return retVal;
+    }
+}

--- a/src/main/java/mcp/mobius/opis/data/holders/newtypes/DataForcedChunks.java
+++ b/src/main/java/mcp/mobius/opis/data/holders/newtypes/DataForcedChunks.java
@@ -43,7 +43,13 @@ public class DataForcedChunks implements ISerializable {
         WorldServer world = DimensionManager.getWorld(dim);
         List<DataForcedChunks> dataList = new ArrayList<>();
 
-        CachedString dimName = new CachedString(world.provider.getDimensionName());
+        String dimNameStr = world.provider.getDimensionName();
+        CachedString dimName;
+        if (dimNameStr != null) {
+            dimName = new CachedString(dimNameStr);
+        } else {
+            dimName = NONE_CACHED;
+        }
 
         SetMultimap<ChunkCoordIntPair, Ticket> ticketMap = world.getPersistentChunks();
         Set<Ticket> tickets = new HashSet<>(ticketMap.values());
@@ -111,7 +117,7 @@ public class DataForcedChunks implements ISerializable {
             }
             if (chunkX != null && chunkZ != null) {
                 ChunkCoordIntPair chunkPos = new ChunkCoordIntPair(chunkX, chunkZ);
-                this.type = new CachedString(
+                this.position = new CachedString(
                         String.format("[ %4d ? %4d ]", chunkPos.getCenterXPos(), chunkPos.getCenterZPosition()));
                 return;
             }

--- a/src/main/java/mcp/mobius/opis/data/holders/newtypes/DataForcedChunks.java
+++ b/src/main/java/mcp/mobius/opis/data/holders/newtypes/DataForcedChunks.java
@@ -53,7 +53,11 @@ public class DataForcedChunks implements ISerializable {
             // Basic Information
             data.dim = dim;
             data.dimName = dimName;
-            data.modId = new CachedString(ticket.getModId());
+            if (ticket.getModId() != null) {
+                data.modId = new CachedString(ticket.getModId());
+            } else {
+                data.modId = NONE_CACHED;
+            }
 
             // Report the player name, if available. Otherwise, report the associated entity.
             // If neither are available, show "N/A."

--- a/src/main/java/mcp/mobius/opis/data/holders/newtypes/DataForcedChunks.java
+++ b/src/main/java/mcp/mobius/opis/data/holders/newtypes/DataForcedChunks.java
@@ -152,6 +152,8 @@ public class DataForcedChunks implements ISerializable {
             type = "Town: " + raw.getString("townName");
         } else if (raw.hasKey("poppetX", Constants.NBT.TAG_INT)) { // Witchery
             type = "Poppet";
+        } else if (raw.hasKey("OwnerType", Constants.NBT.TAG_STRING)) { // GregTech
+            type = raw.getString("OwnerType");
         }
 
         if (type != null) {

--- a/src/main/java/mcp/mobius/opis/data/holders/newtypes/DataForcedChunks.java
+++ b/src/main/java/mcp/mobius/opis/data/holders/newtypes/DataForcedChunks.java
@@ -99,18 +99,36 @@ public class DataForcedChunks implements ISerializable {
             xCoord = raw.getInteger("xCoord");
         } else if (raw.hasKey("OwnerX", Constants.NBT.TAG_INT)) { // GregTech
             xCoord = raw.getInteger("OwnerX");
+        } else if (raw.hasKey("x", Constants.NBT.TAG_INT)) { // Extra Utilities
+            xCoord = raw.getInteger("x");
+        } else if (raw.hasKey("poppetX", Constants.NBT.TAG_INT)) { // Witchery
+            xCoord = raw.getInteger("poppetX");
+        } else if (raw.hasKey("ChunkLoaderTileX", Constants.NBT.TAG_INT)) { // Galacticraft
+            xCoord = raw.getInteger("ChunkLoaderTileX");
         }
 
         if (raw.hasKey("yCoord", Constants.NBT.TAG_INT)) { // Railcraft
             yCoord = raw.getInteger("yCoord");
         } else if (raw.hasKey("OwnerY", Constants.NBT.TAG_INT)) { // GregTech
             yCoord = raw.getInteger("OwnerY");
+        } else if (raw.hasKey("y", Constants.NBT.TAG_INT)) { // Extra Utilities
+            yCoord = raw.getInteger("y");
+        } else if (raw.hasKey("poppetY", Constants.NBT.TAG_INT)) { // Witchery
+            yCoord = raw.getInteger("poppetY");
+        } else if (raw.hasKey("ChunkLoaderTileY", Constants.NBT.TAG_INT)) { // Galacticraft
+            yCoord = raw.getInteger("ChunkLoaderTileY");
         }
 
         if (raw.hasKey("zCoord", Constants.NBT.TAG_INT)) { // Railcraft
             zCoord = raw.getInteger("zCoord");
         } else if (raw.hasKey("OwnerZ", Constants.NBT.TAG_INT)) { // GregTech
             zCoord = raw.getInteger("OwnerZ");
+        } else if (raw.hasKey("z", Constants.NBT.TAG_INT)) { // Extra Utilities
+            zCoord = raw.getInteger("z");
+        } else if (raw.hasKey("poppetZ", Constants.NBT.TAG_INT)) { // Witchery
+            zCoord = raw.getInteger("poppetZ");
+        } else if (raw.hasKey("ChunkLoaderTileZ", Constants.NBT.TAG_INT)) { // Galacticraft
+            zCoord = raw.getInteger("ChunkLoaderTileZ");
         }
 
         if (xCoord != 0 && yCoord != 0 && zCoord != 0) {
@@ -124,7 +142,12 @@ public class DataForcedChunks implements ISerializable {
         String type = null;
         if (raw.hasKey("type", Constants.NBT.TAG_STRING)) { // Railcraft
             type = raw.getString("type");
+        } else if (raw.hasKey("id", Constants.NBT.TAG_STRING)) { // Extra Utilities
+            type = raw.getString("id");
+        } else if (raw.hasKey("townName", Constants.NBT.TAG_STRING)) { // MyTown2
+            type = "Town: " + raw.getString("townName");
         }
+
         if (type != null) {
             this.type = new CachedString(type);
         } else {

--- a/src/main/java/mcp/mobius/opis/data/holders/newtypes/DataForcedChunks.java
+++ b/src/main/java/mcp/mobius/opis/data/holders/newtypes/DataForcedChunks.java
@@ -32,6 +32,7 @@ public class DataForcedChunks implements ISerializable {
     public CachedString playerOrEntityName;
 
     public CachedString rawData;
+    public int numChunks;
     public CachedString chunks;
 
     // Optimistic data we may be able to collect
@@ -79,7 +80,8 @@ public class DataForcedChunks implements ISerializable {
 
             // Chunk positions
             StringBuilder sb = new StringBuilder();
-            Iterator<ChunkCoordIntPair> itr = ticket.getChunkList().iterator();
+            Set<ChunkCoordIntPair> chunkSet = ticket.getChunkList();
+            Iterator<ChunkCoordIntPair> itr = chunkSet.iterator();
             while (itr.hasNext()) {
                 ChunkCoordIntPair coord = itr.next();
                 sb.append("(");
@@ -91,6 +93,7 @@ public class DataForcedChunks implements ISerializable {
                     sb.append(", ");
                 }
             }
+            data.numChunks = chunkSet.size();
             data.chunks = new CachedString(sb.toString());
         }
         return dataList;
@@ -172,6 +175,7 @@ public class DataForcedChunks implements ISerializable {
         position.writeToStream(stream);
         type.writeToStream(stream);
         rawData.writeToStream(stream);
+        stream.writeInt(numChunks);
         chunks.writeToStream(stream);
     }
 
@@ -185,6 +189,7 @@ public class DataForcedChunks implements ISerializable {
         retVal.position = CachedString.readFromStream(stream);
         retVal.type = CachedString.readFromStream(stream);
         retVal.rawData = CachedString.readFromStream(stream);
+        retVal.numChunks = stream.readInt();
         retVal.chunks = CachedString.readFromStream(stream);
 
         return retVal;

--- a/src/main/java/mcp/mobius/opis/events/OpisServerTickHandler.java
+++ b/src/main/java/mcp/mobius/opis/events/OpisServerTickHandler.java
@@ -15,6 +15,7 @@ import mcp.mobius.mobiuscore.profiler.ProfilerSection;
 import mcp.mobius.opis.data.holders.basetypes.SerialInt;
 import mcp.mobius.opis.data.holders.basetypes.SerialLong;
 import mcp.mobius.opis.data.holders.newtypes.DataDimension;
+import mcp.mobius.opis.data.holders.newtypes.DataForcedChunks;
 import mcp.mobius.opis.data.holders.newtypes.DataPacket;
 import mcp.mobius.opis.data.holders.newtypes.DataPacket250;
 import mcp.mobius.opis.data.holders.newtypes.DataThread;
@@ -111,11 +112,14 @@ public enum OpisServerTickHandler {
             }
 
             // Dimension data update.
-            ArrayList<DataDimension> dimData = new ArrayList<DataDimension>();
+            ArrayList<DataDimension> dimData = new ArrayList<>();
+            ArrayList<DataForcedChunks> forcedChunkData = new ArrayList<>();
             for (int dim : DimensionManager.getIDs()) {
                 dimData.add(new DataDimension().fill(dim));
+                forcedChunkData.addAll(DataForcedChunks.getAll(dim));
             }
             PacketManager.sendPacketToAllSwing(new NetDataList(Message.LIST_DIMENSION_DATA, dimData));
+            PacketManager.sendPacketToAllSwing(new NetDataList(Message.LIST_FORCE_CHUNK_DATA, forcedChunkData));
 
             // Profiler update (if running)
             if (modOpis.profilerRun) {

--- a/src/main/java/mcp/mobius/opis/network/enums/Message.java
+++ b/src/main/java/mcp/mobius/opis/network/enums/Message.java
@@ -24,6 +24,7 @@ public enum Message {
     LIST_AMOUNT_TILEENTS,
     LIST_PLAYERS(EnumSet.of(SelectedTab.PLAYERS)),
     LIST_DIMENSION_DATA(EnumSet.of(SelectedTab.DIMENSIONS)),
+    LIST_FORCE_CHUNK_DATA(EnumSet.of(SelectedTab.FORCELOADS)),
     LIST_PACKETS_OUTBOUND(EnumSet.of(SelectedTab.PACKETOUTBOUND)),
     LIST_PACKETS_INBOUND(EnumSet.of(SelectedTab.PACKETINBOUND)),
     LIST_PACKETS_OUTBOUND_250(EnumSet.of(SelectedTab.PACKETOUTBOUND250)),
@@ -143,6 +144,7 @@ public enum Message {
         Message.LIST_AMOUNT_TILEENTS.setAccessLevel(level);
         Message.LIST_PLAYERS.setAccessLevel(level);
         Message.LIST_DIMENSION_DATA.setAccessLevel(level);
+        Message.LIST_FORCE_CHUNK_DATA.setAccessLevel(level);
         Message.LIST_PACKETS_OUTBOUND.setAccessLevel(level);
         Message.LIST_PACKETS_INBOUND.setAccessLevel(level);
         Message.LIST_PACKETS_OUTBOUND_250.setAccessLevel(level);

--- a/src/main/java/mcp/mobius/opis/proxy/ProxyClient.java
+++ b/src/main/java/mcp/mobius/opis/proxy/ProxyClient.java
@@ -41,6 +41,7 @@ import mcp.mobius.opis.swing.panels.timingserver.PanelTimingTileEntsPerClass;
 import mcp.mobius.opis.swing.panels.tracking.PanelAmountEntities;
 import mcp.mobius.opis.swing.panels.tracking.PanelAmountTileEnts;
 import mcp.mobius.opis.swing.panels.tracking.PanelDimensions;
+import mcp.mobius.opis.swing.panels.tracking.PanelForceLoadsPerDim;
 import mcp.mobius.opis.swing.panels.tracking.PanelPlayers;
 
 public class ProxyClient extends ProxyServer implements IMessageHandler {
@@ -63,6 +64,8 @@ public class ProxyClient extends ProxyServer implements IMessageHandler {
                 .registerTab(new PanelAmountTileEnts(), "Tile Entities", "Tracking");
         IMessageHandler panelDimensions = (IMessageHandler) TabPanelRegistrar.INSTANCE
                 .registerTab(new PanelDimensions(), "Dimensions", "Tracking");
+        IMessageHandler panelForcedChunks = (IMessageHandler) TabPanelRegistrar.INSTANCE
+                .registerTab(new PanelForceLoadsPerDim(), "Forced Chunks", "Tracking");
 
         TabPanelRegistrar.INSTANCE.registerSection("Server timing");
         IMessageHandler panelTimingTileEnts = (IMessageHandler) TabPanelRegistrar.INSTANCE
@@ -168,6 +171,7 @@ public class ProxyClient extends ProxyServer implements IMessageHandler {
         MessageHandlerRegistrar.INSTANCE.registerHandler(Message.STATUS_PING, panelSummary);
 
         MessageHandlerRegistrar.INSTANCE.registerHandler(Message.LIST_DIMENSION_DATA, panelDimensions);
+        MessageHandlerRegistrar.INSTANCE.registerHandler(Message.LIST_FORCE_CHUNK_DATA, panelForcedChunks);
 
         MessageHandlerRegistrar.INSTANCE.registerHandler(Message.LIST_PACKETS_OUTBOUND, panelPacketsOut);
         MessageHandlerRegistrar.INSTANCE.registerHandler(Message.LIST_PACKETS_INBOUND, panelPacketsIn);

--- a/src/main/java/mcp/mobius/opis/swing/SelectedTab.java
+++ b/src/main/java/mcp/mobius/opis/swing/SelectedTab.java
@@ -4,6 +4,7 @@ public enum SelectedTab {
     AMOUNTENTS,
     AMOUNTTES,
     DIMENSIONS,
+    FORCELOADS,
     PACKETS,
     PLAYERS,
     RENDERENTITIES,

--- a/src/main/java/mcp/mobius/opis/swing/panels/tracking/PanelForceLoadsPerDim.java
+++ b/src/main/java/mcp/mobius/opis/swing/panels/tracking/PanelForceLoadsPerDim.java
@@ -1,0 +1,74 @@
+package mcp.mobius.opis.swing.panels.tracking;
+
+import javax.swing.JScrollPane;
+import javax.swing.SwingUtilities;
+import javax.swing.table.DefaultTableModel;
+
+import net.miginfocom.swing.MigLayout;
+
+import mcp.mobius.opis.api.ITabPanel;
+import mcp.mobius.opis.data.holders.newtypes.DataForcedChunks;
+import mcp.mobius.opis.network.PacketBase;
+import mcp.mobius.opis.network.enums.Message;
+import mcp.mobius.opis.swing.SelectedTab;
+import mcp.mobius.opis.swing.widgets.JPanelMsgHandler;
+import mcp.mobius.opis.swing.widgets.JTableStats;
+
+public class PanelForceLoadsPerDim extends JPanelMsgHandler implements ITabPanel {
+
+    // todo serialVersionUID
+
+    public PanelForceLoadsPerDim() {
+        setLayout(new MigLayout("", "[grow]", "[grow]"));
+
+        JScrollPane scrollPane = new JScrollPane();
+        add(scrollPane, "cell 0 0,grow");
+
+        table = new JTableStats(
+                new String[] { "Dim", "Name", "Mod Id", "Player or Entity", "Position", "Type", "Chunks", "Raw Data" },
+                new Class[] { Integer.class, String.class, String.class, String.class, String.class, String.class,
+                        String.class, String.class },
+                new boolean[] { false, false, false, false, false, false, false, false });
+        table.setBackground(this.getBackground());
+        table.setAutoCreateRowSorter(true);
+        table.setShowGrid(false);
+        scrollPane.setViewportView(table);
+    }
+
+    @Override
+    public boolean handleMessage(Message msg, PacketBase rawdata) {
+        switch (msg) {
+            case LIST_FORCE_CHUNK_DATA: {
+                this.cacheData(msg, rawdata);
+                SwingUtilities.invokeLater(() -> {
+                    this.getTable().setTableData(rawdata.array);
+
+                    DefaultTableModel model = this.getTable().getModel();
+                    int row = this.getTable().clearTable(DataForcedChunks.class);
+
+                    for (Object o : rawdata.array) {
+                        DataForcedChunks data = (DataForcedChunks) o;
+                        model.addRow(
+                                new Object[] { data.dim, data.dimName, data.modId, data.playerOrEntityName,
+                                        data.position, data.type, data.chunks, data.rawData });
+                    }
+                    this.getTable().dataUpdated(row);
+                });
+                break;
+            }
+            default:
+                return false;
+        }
+        return true;
+    }
+
+    @Override
+    public SelectedTab getSelectedTab() {
+        return SelectedTab.FORCELOADS;
+    }
+
+    @Override
+    public boolean refreshOnString() {
+        return true;
+    }
+}

--- a/src/main/java/mcp/mobius/opis/swing/panels/tracking/PanelForceLoadsPerDim.java
+++ b/src/main/java/mcp/mobius/opis/swing/panels/tracking/PanelForceLoadsPerDim.java
@@ -1,5 +1,8 @@
 package mcp.mobius.opis.swing.panels.tracking;
 
+import java.util.Arrays;
+import java.util.Vector;
+
 import javax.swing.JScrollPane;
 import javax.swing.SwingUtilities;
 import javax.swing.table.DefaultTableModel;
@@ -44,16 +47,27 @@ public class PanelForceLoadsPerDim extends JPanelMsgHandler implements ITabPanel
                 SwingUtilities.invokeLater(() -> {
                     this.getTable().setTableData(rawdata.array);
 
-                    DefaultTableModel model = this.getTable().getModel();
-                    int row = this.getTable().clearTable(DataForcedChunks.class);
+                    final DefaultTableModel model = this.getTable().getModel();
+                    final int lastSelectedRow = this.getTable().clearTable(DataForcedChunks.class);
 
+                    final Vector<Vector> dataVector = model.getDataVector();
+                    dataVector.clear();
                     for (Object o : rawdata.array) {
                         DataForcedChunks data = (DataForcedChunks) o;
-                        model.addRow(
-                                new Object[] { data.dim, data.dimName, data.modId, data.playerOrEntityName,
-                                        data.position, data.type, data.numChunks, data.chunks, data.rawData });
+                        dataVector.add(
+                                new Vector(
+                                        Arrays.asList(
+                                                data.dim,
+                                                data.dimName.toString(),
+                                                data.modId.toString(),
+                                                data.playerOrEntityName.toString(),
+                                                data.position.toString(),
+                                                data.type.toString(),
+                                                data.numChunks,
+                                                data.chunks.toString(),
+                                                data.rawData.toString())));
                     }
-                    this.getTable().dataUpdated(row);
+                    this.getTable().dataUpdated(lastSelectedRow);
                 });
                 break;
             }

--- a/src/main/java/mcp/mobius/opis/swing/panels/tracking/PanelForceLoadsPerDim.java
+++ b/src/main/java/mcp/mobius/opis/swing/panels/tracking/PanelForceLoadsPerDim.java
@@ -16,7 +16,7 @@ import mcp.mobius.opis.swing.widgets.JTableStats;
 
 public class PanelForceLoadsPerDim extends JPanelMsgHandler implements ITabPanel {
 
-    // todo serialVersionUID
+    private static final long serialVersionUID = 3487495895819393L;
 
     public PanelForceLoadsPerDim() {
         setLayout(new MigLayout("", "[grow]", "[grow]"));

--- a/src/main/java/mcp/mobius/opis/swing/panels/tracking/PanelForceLoadsPerDim.java
+++ b/src/main/java/mcp/mobius/opis/swing/panels/tracking/PanelForceLoadsPerDim.java
@@ -25,10 +25,11 @@ public class PanelForceLoadsPerDim extends JPanelMsgHandler implements ITabPanel
         add(scrollPane, "cell 0 0,grow");
 
         table = new JTableStats(
-                new String[] { "Dim", "Name", "Mod Id", "Player or Entity", "Position", "Type", "Chunks", "Raw Data" },
+                new String[] { "Dim", "Name", "Mod Id", "Player or Entity", "Position", "Type", "Num Chunks", "Chunks",
+                        "Raw Data" },
                 new Class[] { Integer.class, String.class, String.class, String.class, String.class, String.class,
-                        String.class, String.class },
-                new boolean[] { false, false, false, false, false, false, false, false });
+                        Integer.class, String.class, String.class },
+                new boolean[] { false, false, false, false, false, false, false, false, false });
         table.setBackground(this.getBackground());
         table.setAutoCreateRowSorter(true);
         table.setShowGrid(false);
@@ -50,7 +51,7 @@ public class PanelForceLoadsPerDim extends JPanelMsgHandler implements ITabPanel
                         DataForcedChunks data = (DataForcedChunks) o;
                         model.addRow(
                                 new Object[] { data.dim, data.dimName, data.modId, data.playerOrEntityName,
-                                        data.position, data.type, data.chunks, data.rawData });
+                                        data.position, data.type, data.numChunks, data.chunks, data.rawData });
                     }
                     this.getTable().dataUpdated(row);
                 });


### PR DESCRIPTION
Adds a new tab to Opis' `Tracking` tab which displays all forge forced chunk tickets. Example:
![image](https://github.com/user-attachments/assets/b9d8a7ed-a89a-47ff-ab15-ec290dd8893c)

Description of each entry in the table:
- `Dim`: The dimension ID where chunks are force loaded
- `Name`: The name of said dimension
- `Mod Id`: The mod that owns this ticket
- `Player or Entity`: The player who owns this ticket, if player owned. If not, it will be the class name of the entity that owns this ticket, if it is an entity ticket. If it is not, then it will be "N/A"
- `Position`: An "optimistic" chunk loader position, which is attempted to be determined from the raw data. Will be `N/A` if there is no known NBT key that provides an exact position
- `Type`: An "optimistic" type, which is attempted to be determined from the raw data. Will be `N/A` if there is no known NBT key that provides a type
- `Raw Data`: Raw NBT data set to this ticket. Every mod chooses what to put here, if anything. This will vary greatly for every force loading solution
- `Chunks`: List of all chunk positions force loaded by this ticket

Currently, I have gathered all data out of the "raw data" section for railcraft and gregtech force loads. The main effort going forward will be testing this in the full pack on an established server with lots of force loaded chunks and seeing if there is more data we can gather from this "raw data" section to separate out into its own section from other modded chunk loaders
