### PR TITLE
Fix running in a headless Swing/AWT environment

### DIFF
--- a/src/main/java/mcp/mobius/opis/api/MessageHandlerRegistrar.java
+++ b/src/main/java/mcp/mobius/opis/api/MessageHandlerRegistrar.java
@@ -12,6 +12,7 @@ public enum MessageHandlerRegistrar {
     INSTANCE;
 
     private HashMap<Message, HashSet<IMessageHandler>> msgHandlers = new HashMap<Message, HashSet<IMessageHandler>>();
+    public boolean suppressUnhandledMsgLogs = false;
 
     public void registerHandler(Message msg, IMessageHandler handler) {
         if (!msgHandlers.containsKey(msg)) msgHandlers.put(msg, new HashSet<IMessageHandler>());
@@ -27,7 +28,7 @@ public enum MessageHandlerRegistrar {
                     modOpis.log.warn(String.format("Unhandled msg %s in handler %s", msg, handler));
                 }
             }
-        } else {
+        } else if (!suppressUnhandledMsgLogs) {
             modOpis.log.warn(String.format("Unhandled msg : %s", msg));
         }
     }

--- a/src/main/java/mcp/mobius/opis/modOpis.java
+++ b/src/main/java/mcp/mobius/opis/modOpis.java
@@ -96,6 +96,7 @@ public class modOpis {
     public modOpis() throws ReflectiveOperationException {
         final boolean isHeadless = Boolean.getBoolean("java.awt.headless");
         if (FMLLaunchHandler.side().isClient() && !isHeadless) {
+            // Instantiate via reflection to avoid triggering client-only class loading
             proxy = (ProxyServer) Class.forName("mcp.mobius.opis.proxy.ProxyClient").getConstructor().newInstance();
         } else {
             proxy = new ProxyServer();

--- a/src/main/java/mcp/mobius/opis/proxy/ProxyClient.java
+++ b/src/main/java/mcp/mobius/opis/proxy/ProxyClient.java
@@ -49,6 +49,11 @@ public class ProxyClient extends ProxyServer implements IMessageHandler {
     public static TrueTypeFont fontMC8, fontMC12, fontMC16, fontMC18, fontMC24;
 
     @Override
+    public boolean isClient() {
+        return true;
+    }
+
+    @Override
     public void init() {
         fontMC8 = Fonts.createFont(new ResourceLocation("opis", "fonts/LiberationMono-Bold.ttf"), 14, true);
 

--- a/src/main/java/mcp/mobius/opis/proxy/ProxyServer.java
+++ b/src/main/java/mcp/mobius/opis/proxy/ProxyServer.java
@@ -6,6 +6,10 @@ import mcp.mobius.opis.network.enums.Message;
 
 public class ProxyServer implements IMessageHandler {
 
+    public boolean isClient() {
+        return false;
+    }
+
     public void init() {}
 
     @Override


### PR DESCRIPTION
Fixes running with `-Djava.awt.headless=true` as required by lwjgl3ify 3.x by not running any client-side code in that environment (thus avoiding initializing the Swing windowing system).
Can be tested locally with `./gradlew runClient21 --mcJvmArgs=-Djava.awt.headless=true`