### PR TITLE
Fix name for type tab

### DIFF
--- a/src/main/java/mcp/mobius/opis/data/holders/clienttypes/DataBlockRender.java
+++ b/src/main/java/mcp/mobius/opis/data/holders/clienttypes/DataBlockRender.java
@@ -19,9 +19,10 @@ public class DataBlockRender extends DataBlockTileEntity {
     public DataBlockRender fill(CoordinatesBlock coord) {
         this.pos = coord;
         World world = Minecraft.getMinecraft().theWorld; // DimensionManager.getWorld(this.pos.dim);
+        Block block = world.getBlock(this.pos.x, this.pos.y, this.pos.z);
 
-        this.id = (short) Block.getIdFromBlock(world.getBlock(this.pos.x, this.pos.y, this.pos.z));
-        this.meta = (short) world.getBlockMetadata(this.pos.x, this.pos.y, this.pos.z);
+        this.id = Block.getIdFromBlock(block);
+        this.meta = block.getDamageValue(world, this.pos.x, this.pos.y, this.pos.z);
 
         HashMap<CoordinatesBlock, DescriptiveStatistics> data = ((ProfilerRenderBlock) (ProfilerSection.RENDER_BLOCK
                 .getProfiler())).data;

--- a/src/main/java/mcp/mobius/opis/data/managers/TileEntityManager.java
+++ b/src/main/java/mcp/mobius/opis/data/managers/TileEntityManager.java
@@ -228,8 +228,9 @@ public enum TileEntityManager {
         for (CoordinatesBlock coord : ((ProfilerTileEntityUpdate) ProfilerSection.TILEENT_UPDATETIME.getProfiler()).data
                 .keySet()) {
             World world = DimensionManager.getWorld(coord.dim);
-            int id = Block.getIdFromBlock(world.getBlock(coord.x, coord.y, coord.z));
-            int meta = world.getBlockMetadata(coord.x, coord.y, coord.z);
+            Block block = world.getBlock(coord.x, coord.y, coord.z);
+            int id = Block.getIdFromBlock(block);
+            int meta = block.getDamageValue(world, coord.x, coord.y, coord.z);
 
             if (!data.contains(id, meta)) data.put(id, meta, new DataBlockTileEntityPerClass(id, meta));
 


### PR DESCRIPTION
Same as https://github.com/GTNewHorizons/Opis/pull/14 but for the Tile Entity [Type] tab.

<img width="1074" height="518" alt="image" src="https://github.com/user-attachments/assets/e9fccc98-3897-4c91-a3b9-e09855b14d13" />

Basically block meta have no meaning for name as there is no function that convert [block, meta] to name. Item meta should always be used for retrieving name.